### PR TITLE
Gdc phase kickstarter 1 - Add Gitlab Runner Guardrails

### DIFF
--- a/examples/guardrails/folder-factory/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/folder-factory/.gitlab/workflows/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+#The pipeline only gets triggered only when a change is committed to one of the following directories mentioned below. 
+#To update this behavior, add or remove items under changes: section.
 workflow:
   rules:
     - changes:
@@ -17,7 +19,6 @@ variables:
   TF_VERSION: $TF_VERSION    
   TF_ROOT: $TF_ROOT
   TF_LOG: $TF_LOG
-  TF_TIMEOUT: $TF_TIMEOUT
   TF_PLAN_NAME: plan.tfplan
   TF_PLAN_JSON: plan.json
   REFRESH: -refresh=true
@@ -129,5 +130,5 @@ apply:
   script:
     - cd $TF_ROOT
     - terraform apply -auto-approve $TF_PLAN_NAME 
-  when: manual
+  when: manual   #Set as manual currently as WIF doesn't support merge request pipelines for now.
   allow_failure: false

--- a/examples/guardrails/folder-factory/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/folder-factory/.gitlab/workflows/.gitlab-ci.yml
@@ -1,0 +1,133 @@
+workflow:
+  rules:
+    - changes:
+      - "*.tf"
+      - "*.tfvars"
+      - "data/**/*"
+      - "modules/**/*"
+
+# Workflow image
+default:
+  image:
+    name: google/cloud-sdk:slim
+  # pull_policy: if-not-present  #Not allowed on the SaaS gitlab runners.
+
+# Workflow variables. They can be overwritten by passing pipeline Variables in Gitlab repository
+variables:
+  TF_VERSION: $TF_VERSION    
+  TF_ROOT: $TF_ROOT
+  TF_LOG: $TF_LOG
+  TF_TIMEOUT: $TF_TIMEOUT
+  TF_PLAN_NAME: plan.tfplan
+  TF_PLAN_JSON: plan.json
+  REFRESH: -refresh=true
+  STATE_BUCKET: $STATE_BUCKET
+  GCP_PROJECT_ID: $GCP_PROJECT_ID
+  GCP_WORKLOAD_IDENTITY_PROVIDER: $GCP_WORKLOAD_IDENTITY_PROVIDER
+  GCP_SERVICE_ACCOUNT: $GCP_SERVICE_ACCOUNT
+
+# Provides a list of stages for this GitLab workflow
+stages:
+  - setup-terraform
+  - validate
+  - plan
+  - apply
+
+.gcp-auth: &gcp-auth
+    - echo ${CI_JOB_JWT_V2} > .ci_job_jwt_file
+    - gcloud iam workload-identity-pools create-cred-config ${GCP_WORKLOAD_IDENTITY_PROVIDER} --service-account="${GCP_SERVICE_ACCOUNT}" --output-file=.gcp_temp_cred.json --credential-source-file=.ci_job_jwt_file
+    - gcloud auth login --cred-file=`pwd`/.gcp_temp_cred.json
+    - gcloud config set project $GCP_PROJECT_ID
+    - export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/.gcp_temp_cred.json
+
+.terraform-ver-init: &terraform-ver-init
+  - cd $TF_ROOT
+  - cp ./terraform /usr/bin/
+  - terraform init -backend-config="bucket=$STATE_BUCKET" -backend-config="prefix=$CI_PROJECT_NAME" --upgrade=True
+
+# Cache files between jobs
+cache:
+  key: "$CI_COMMIT_SHA"
+  # Globally caches the .terraform folder across each job in this workflow
+  paths:
+    - $TF_ROOT/.terraform
+
+#Job: setup-terraform | Stage: setup-terraform
+# Purpose: downloads specified version of terraform binary and passes it as artifact for the other jobs and stages
+setup-terraform:
+  stage: setup-terraform
+  script:
+    - /bin/sh -c 'apt-get update && apt -y install unzip wget && wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && unzip terraform_${TF_VERSION}_linux_amd64.zip'
+  artifacts:
+    untracked: false
+    paths:
+      - terraform
+
+#Job: tf-fmt | Stage: validate
+# Purpose: check the format (fmt) as a sort of linting test
+tf-fmt:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform fmt -recursive -check
+  allow_failure: false
+    
+# Job: Validate | Stage: Validate
+# Purpose: Syntax Validation for the Terraform configuration files
+validate:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform validate
+  allow_failure: false
+
+#Job: plan | Stage: Plan
+#Runs terraform plan and outputs the plan and a json summary to 
+#local files which are later made available as artifacts.
+plan: 
+  stage: plan
+  dependencies:
+    - setup-terraform
+    - validate
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+    - apt install -y jq 
+    - shopt -s expand_aliases && alias convert_report="jq -r '([.resource_changes[]?.change.actions?]|flatten)|{\"create\":(map(select(.==\"create\"))|length),\"update\":(map(select(.==\"update\"))|length),\"delete\":(map(select(.==\"delete\"))|length)}'"
+  script:
+    - cd $TF_ROOT
+    - terraform plan -out=$TF_PLAN_NAME $REFRESH
+    - terraform show --json $TF_PLAN_NAME | convert_report > $TF_PLAN_JSON
+  allow_failure: false
+
+  artifacts:
+    reports:
+      terraform: ${TF_ROOT}/$TF_PLAN_JSON
+    paths:
+      - ${TF_ROOT}/$TF_PLAN_NAME
+      - ${TF_ROOT}/$TF_PLAN_JSON
+    expire_in: 7 days   #optional. Gitlab stores artifacts of successful pipelines for the most recent commit on each ref. If needed, enable "Keep artifacts from most recent successful jobs"  in CI/CD settings of the repository.
+
+#Stage:apply | job: apply
+# purpose: executes the plan from the file created in the plan stage
+apply:
+  stage: apply
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  dependencies:
+    - setup-terraform
+    - plan
+  script:
+    - cd $TF_ROOT
+    - terraform apply -auto-approve $TF_PLAN_NAME 
+  when: manual
+  allow_failure: false

--- a/examples/guardrails/folder-factory/.gitlab/workflows/README.md
+++ b/examples/guardrails/folder-factory/.gitlab/workflows/README.md
@@ -1,7 +1,7 @@
 
-# Build Repository from Gitlab
+# Terraform pipeline execution with Gitlab runners and Gitlab repository
 
-This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+This workflow runs terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
 
 ## Prerequisites
 

--- a/examples/guardrails/folder-factory/.gitlab/workflows/README.md
+++ b/examples/guardrails/folder-factory/.gitlab/workflows/README.md
@@ -1,0 +1,45 @@
+
+# Build Repository from Gitlab
+
+This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+
+## Prerequisites
+
+* A Gitlab project containing the folder-factory repository
+* Available Gitlab Runners for the project either self hosted or the SaaS Gitlab shared runners.
+* A working WIF provider, pool setup with audience as gitlab.com with neccessary attributes and linked service account with required permissions. For further details, please refer to the official [Gitlab Documentation](https://docs.gitlab.com/ee/ci/cloud_services/google_cloud/)
+
+
+## Setup 
+
+1. Update the CICD configuration file path in the repository
+    * From the folder-factory Gitlab project page, Navigate to Settings > CICD > expand General pipelines 
+    * update CI/CD configuration file value to the relative path of the gitlab-ci.yml file from the root directory
+
+2. Update the CI/CD variables
+    * From the folder-factory project page, Navigate to Settings > CICD > expand Variables
+    * Add the below variables to the pipeline 
+
+| Variable                       | Description                                                                                                                                              | Sample value                                                                                                    |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| GCP_PROJECT_ID                 | The GCP project ID of your service account                                                                                                               | sample-project-1122                                                                                             |
+| GCP_SERVICE_ACCOUNT            | The Service Account to be used for creating folders                                                                                                      | xyz@sample-project-1122.iam.gserviceaccount.com                                                                 |
+| GCP_WORKLOAD_IDENTITY_PROVIDER | The Workload Identity provider URI configured with the Service Account and the repository                                                                | projects/<project-number>/locations/global/workloadIdentityPools/<identity-pool-name>/providers/<provider-name> |
+| STATE_BUCKET                   | The GCS bucket in which the state is to be centrally managed. The Service account provided above must have access to list and write files to this bucket | sample-terraform-state-bucket                                                                                   |
+| TF_LOG                         | The terraform env variable setting to get detailed logs.  Supports TRACE,DEBUG,INFO,WARN,ERROR in order of decreasing verbosity                          | WARN                                                                                                            |
+| TF_ROOT                        | The directory of the terraform code to be executed.  Can be a path string or also a pre-defined gitlab CI variables                                      | $CI_PROJECT_DIR                                                                                                 |
+| TF_VERSION                     | The terraform version to be used for execution. The specified terraform version is downloaded and used for execution for the workflow.                   | 1.3.6                                                                                                           |
+
+## Overview of the Pipeline stages
+The complete workflow consists of 4 stages and 2 before-script jobs
+
+* before_script jobs : 
+    * gcp-auth : creates the wif credentials by impersonating the service account. 
+    * terraform init : initializes terraform in the specified TF_ROOT directory
+
+* Stages: 
+    * setup-terraform : Downloads the specified TF_VERSION and passes it as a binary to the next stages
+    * validate: Runs terraform fmt check and terraform validate. This stage fails if the code is not run against terraform fmt        command
+    * plan: Runs terraform plan and saves the plan and json version of the plan as artifacts
+    * apply: This step is currently set as manual to be triggered from the Gitlab pipelines UI once plan is successful. Runs terraform apply and creates the infrastructure specified.
+

--- a/examples/guardrails/project-factory/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/project-factory/.gitlab/workflows/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+#The pipeline only gets triggered only when a change is committed to one of the following directories mentioned below. 
+#To update this behavior, add or remove items under changes: section.
 workflow:
   rules:
     - changes:
@@ -17,7 +19,6 @@ variables:
   TF_VERSION: $TF_VERSION    
   TF_ROOT: $TF_ROOT
   TF_LOG: $TF_LOG
-  TF_TIMEOUT: $TF_TIMEOUT
   TF_PLAN_NAME: plan.tfplan
   TF_PLAN_JSON: plan.json
   REFRESH: -refresh=true
@@ -129,5 +130,5 @@ apply:
   script:
     - cd $TF_ROOT
     - terraform apply -auto-approve $TF_PLAN_NAME 
-  when: manual
+  when: manual   #Set as manual currently as WIF doesn't support merge request pipelines for now.
   allow_failure: false

--- a/examples/guardrails/project-factory/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/project-factory/.gitlab/workflows/.gitlab-ci.yml
@@ -1,0 +1,133 @@
+workflow:
+  rules:
+    - changes:
+      - "*.tf"
+      - "*.tfvars"
+      - "data/**/*"
+      - "modules/**/*"
+
+# Workflow image
+default:
+  image:
+    name: google/cloud-sdk:slim
+  # pull_policy: if-not-present  #Not allowed on the SaaS gitlab runners.
+
+# Workflow variables. They can be overwritten by passing pipeline Variables in Gitlab repository
+variables:
+  TF_VERSION: $TF_VERSION    
+  TF_ROOT: $TF_ROOT
+  TF_LOG: $TF_LOG
+  TF_TIMEOUT: $TF_TIMEOUT
+  TF_PLAN_NAME: plan.tfplan
+  TF_PLAN_JSON: plan.json
+  REFRESH: -refresh=true
+  STATE_BUCKET: $STATE_BUCKET
+  GCP_PROJECT_ID: $GCP_PROJECT_ID
+  GCP_WORKLOAD_IDENTITY_PROVIDER: $GCP_WORKLOAD_IDENTITY_PROVIDER
+  GCP_SERVICE_ACCOUNT: $GCP_SERVICE_ACCOUNT
+
+# Provides a list of stages for this GitLab workflow
+stages:
+  - setup-terraform
+  - validate
+  - plan
+  - apply
+
+.gcp-auth: &gcp-auth
+    - echo ${CI_JOB_JWT_V2} > .ci_job_jwt_file
+    - gcloud iam workload-identity-pools create-cred-config ${GCP_WORKLOAD_IDENTITY_PROVIDER} --service-account="${GCP_SERVICE_ACCOUNT}" --output-file=.gcp_temp_cred.json --credential-source-file=.ci_job_jwt_file
+    - gcloud auth login --cred-file=`pwd`/.gcp_temp_cred.json
+    - gcloud config set project $GCP_PROJECT_ID
+    - export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/.gcp_temp_cred.json
+
+.terraform-ver-init: &terraform-ver-init
+  - cd $TF_ROOT
+  - cp ./terraform /usr/bin/
+  - terraform init -backend-config="bucket=$STATE_BUCKET" -backend-config="prefix=$CI_PROJECT_NAME" --upgrade=True
+
+# Cache files between jobs
+cache:
+  key: "$CI_COMMIT_SHA"
+  # Globally caches the .terraform folder across each job in this workflow
+  paths:
+    - $TF_ROOT/.terraform
+
+#Job: setup-terraform | Stage: setup-terraform
+# Purpose: downloads specified version of terraform binary and passes it as artifact for the other jobs and stages
+setup-terraform:
+  stage: setup-terraform
+  script:
+    - /bin/sh -c 'apt-get update && apt -y install unzip wget && wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && unzip terraform_${TF_VERSION}_linux_amd64.zip'
+  artifacts:
+    untracked: false
+    paths:
+      - terraform
+
+#Job: tf-fmt | Stage: validate
+# Purpose: check the format (fmt) as a sort of linting test
+tf-fmt:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform fmt -recursive -check
+  allow_failure: false
+    
+# Job: Validate | Stage: Validate
+# Purpose: Syntax Validation for the Terraform configuration files
+validate:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform validate
+  allow_failure: false
+
+#Job: plan | Stage: Plan
+#Runs terraform plan and outputs the plan and a json summary to 
+#local files which are later made available as artifacts.
+plan: 
+  stage: plan
+  dependencies:
+    - setup-terraform
+    - validate
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+    - apt install -y jq 
+    - shopt -s expand_aliases && alias convert_report="jq -r '([.resource_changes[]?.change.actions?]|flatten)|{\"create\":(map(select(.==\"create\"))|length),\"update\":(map(select(.==\"update\"))|length),\"delete\":(map(select(.==\"delete\"))|length)}'"
+  script:
+    - cd $TF_ROOT
+    - terraform plan -out=$TF_PLAN_NAME $REFRESH
+    - terraform show --json $TF_PLAN_NAME | convert_report > $TF_PLAN_JSON
+  allow_failure: false
+
+  artifacts:
+    reports:
+      terraform: ${TF_ROOT}/$TF_PLAN_JSON
+    paths:
+      - ${TF_ROOT}/$TF_PLAN_NAME
+      - ${TF_ROOT}/$TF_PLAN_JSON
+    expire_in: 7 days   #optional. Gitlab stores artifacts of successful pipelines for the most recent commit on each ref. If needed, enable "Keep artifacts from most recent successful jobs"  in CI/CD settings of the repository.
+
+#Stage:apply | job: apply
+# purpose: executes the plan from the file created in the plan stage
+apply:
+  stage: apply
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  dependencies:
+    - setup-terraform
+    - plan
+  script:
+    - cd $TF_ROOT
+    - terraform apply -auto-approve $TF_PLAN_NAME 
+  when: manual
+  allow_failure: false

--- a/examples/guardrails/project-factory/.gitlab/workflows/README.md
+++ b/examples/guardrails/project-factory/.gitlab/workflows/README.md
@@ -1,7 +1,7 @@
 
-# Build Repository from Gitlab
+# Terraform pipeline execution with Gitlab runners and Gitlab repository
 
-This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+This workflow runs terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
 
 ## Prerequisites
 

--- a/examples/guardrails/project-factory/.gitlab/workflows/README.md
+++ b/examples/guardrails/project-factory/.gitlab/workflows/README.md
@@ -1,0 +1,45 @@
+
+# Build Repository from Gitlab
+
+This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+
+## Prerequisites
+
+* A Gitlab project containing the project-factory repository
+* Available Gitlab Runners for the project either self hosted or the SaaS Gitlab shared runners.
+* A working WIF provider, pool setup with audience as gitlab.com with neccessary attributes and linked service account with required permissions. For further details, please refer to the official [Gitlab Documentation](https://docs.gitlab.com/ee/ci/cloud_services/google_cloud/)
+
+
+## Setup 
+
+1. Update the CICD configuration file path in the repository
+    * From the project-factory Gitlab project page, Navigate to Settings > CICD > expand General pipelines 
+    * update CI/CD configuration file value to the relative path of the gitlab-ci.yml file from the root directory
+
+2. Update the CI/CD variables
+    * From the project-factory project page, Navigate to Settings > CICD > expand Variables
+    * Add the below variables to the pipeline 
+
+| Variable                       | Description                                                                                                                                              | Sample value                                                                                                    |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| GCP_PROJECT_ID                 | The GCP project ID of your service account                                                                                                               | sample-project-1122                                                                                             |
+| GCP_SERVICE_ACCOUNT            | The Service Account to be used for creating projects                                                                                                      | xyz@sample-project-1122.iam.gserviceaccount.com                                                                 |
+| GCP_WORKLOAD_IDENTITY_PROVIDER | The Workload Identity provider URI configured with the Service Account and the repository                                                                | projects/<project-number>/locations/global/workloadIdentityPools/<identity-pool-name>/providers/<provider-name> |
+| STATE_BUCKET                   | The GCS bucket in which the state is to be centrally managed. The Service account provided above must have access to list and write files to this bucket | sample-terraform-state-bucket                                                                                   |
+| TF_LOG                         | The terraform env variable setting to get detailed logs.  Supports TRACE,DEBUG,INFO,WARN,ERROR in order of decreasing verbosity                          | WARN                                                                                                            |
+| TF_ROOT                        | The directory of the terraform code to be executed.  Can be a path string or also a pre-defined gitlab CI variables                                      | $CI_PROJECT_DIR                                                                                                 |
+| TF_VERSION                     | The terraform version to be used for execution. The specified terraform version is downloaded and used for execution for the workflow.                   | 1.3.6                                                                                                           |
+
+## Overview of the Pipeline stages
+The complete workflow consists of 4 stages and 2 before-script jobs
+
+* before_script jobs : 
+    * gcp-auth : creates the wif credentials by impersonating the service account. 
+    * terraform init : initializes terraform in the specified TF_ROOT directory
+
+* Stages: 
+    * setup-terraform : Downloads the specified TF_VERSION and passes it as a binary to the next stages
+    * validate: Runs terraform fmt check and terraform validate. This stage fails if the code is not run against terraform fmt        command
+    * plan: Runs terraform plan and saves the plan and json version of the plan as artifacts
+    * apply: This step is currently set as manual to be triggered from the Gitlab pipelines UI once plan is successful. Runs terraform apply and creates the infrastructure specified.
+

--- a/examples/guardrails/project-factory/main.tf
+++ b/examples/guardrails/project-factory/main.tf
@@ -25,11 +25,11 @@ module "project" {
   source          = "./modules/project_plus"
   for_each        = local.projects
   team            = each.key
-  repo_sub        = "${each.value.repo_provider == "gitlab" ? "project_path:${each.value.repo_name}:ref_type:branch:ref:${each.value.repo_branch}" : "repo:${each.value.repo_name}:ref:refs/heads/${each.value.repo_branch}"}" 
+  repo_sub        = each.value.repo_provider == "gitlab" ? "project_path:${each.value.repo_name}:ref_type:branch:ref:${each.value.repo_branch}" : "repo:${each.value.repo_name}:ref:refs/heads/${each.value.repo_branch}"
   repo_provider   = each.value.repo_provider
   billing_account = each.value.billing_account_id
   folder          = var.folder
   roles           = try(each.value.roles, [])
-  wif-pool        = "${each.value.repo_provider == "gitlab" ? google_iam_workload_identity_pool.wif-pool-gitlab.name : google_iam_workload_identity_pool.wif-pool-github.name}"
+  wif-pool        = each.value.repo_provider == "gitlab" ? google_iam_workload_identity_pool.wif-pool-gitlab.name : google_iam_workload_identity_pool.wif-pool-github.name
   depends_on      = [google_iam_workload_identity_pool.wif-pool-github,google_iam_workload_identity_pool.wif-pool-gitlab]
 }

--- a/examples/guardrails/project-factory/wif.tf
+++ b/examples/guardrails/project-factory/wif.tf
@@ -41,7 +41,8 @@ resource "google_iam_workload_identity_pool_provider" "wif-provider-gitlab" {
     "attribute.sub" = "assertion.sub"
   }
   oidc {
-    issuer_uri        = "https://gitlab.com"
+    issuer_uri        = "https://gitlab.com/"
+    allowed_audiences = ["https://gitlab.com"]
   }
 }
 

--- a/examples/guardrails/skunkworks/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/.gitlab-ci.yml
@@ -1,0 +1,47 @@
+stages:
+  - triggers
+
+variables:
+  STATE_BUCKET: $STATE_BUCKET
+  GCP_WORKLOAD_IDENTITY_PROVIDER: $GCP_WORKLOAD_IDENTITY_PROVIDER
+  TF_VERSION: $TF_VERSION
+  TF_LOG: $TF_LOG
+  TF_ROOT: $TF_ROOT
+  TF_TIMEOUT: $TF_TIMEOUT
+
+trigger_dev:
+  variables:
+    GCP_PROJECT_ID: $DEV_GCP_PROJECT_ID
+    GCP_SERVICE_ACCOUNT: $DEV_GCP_SERVICE_ACCOUNT
+    ENVIRONMENT: dev
+  stage: triggers
+  trigger:
+    include: .gitlab/workflows/workflow.yml
+    strategy: depend
+  only:
+    - dev
+    
+trigger_staging:
+  stage: triggers
+  variables:
+    GCP_PROJECT_ID: $STAGE_GCP_PROJECT_ID
+    GCP_SERVICE_ACCOUNT: $STAGE_GCP_SERVICE_ACCOUNT
+    ENVIRONMENT: staging
+  trigger:
+    include: .gitlab/workflows/workflow.yml
+    strategy: depend
+  only:
+    - staging
+
+trigger_prod:
+  stage: triggers
+  variables:
+    GCP_PROJECT_ID: $PROD_PROJECT_ID
+    GCP_SERVICE_ACCOUNT: $PROD_GCP_SERVICE_ACCOUNT
+    ENVIRONMENT: prod
+  trigger:
+    include: .gitlab/workflows/workflow.yml
+    strategy: depend
+  only:
+    - prod
+    

--- a/examples/guardrails/skunkworks/.gitlab/workflows/.gitlab-ci.yml
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/.gitlab-ci.yml
@@ -7,7 +7,6 @@ variables:
   TF_VERSION: $TF_VERSION
   TF_LOG: $TF_LOG
   TF_ROOT: $TF_ROOT
-  TF_TIMEOUT: $TF_TIMEOUT
 
 trigger_dev:
   variables:

--- a/examples/guardrails/skunkworks/.gitlab/workflows/README.md
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/README.md
@@ -1,7 +1,7 @@
 
-# Build Repository from Gitlab
+# Terraform pipeline execution with Gitlab runners and Gitlab repository
 
-This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+This workflow runs terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
 
 ## Prerequisites
 

--- a/examples/guardrails/skunkworks/.gitlab/workflows/README.md
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/README.md
@@ -1,0 +1,54 @@
+
+# Build Repository from Gitlab
+
+This workflow is to run terraform pipelines using Gitlab CICD. This document covers the steps to setup Gitlab CICD and provides a high level overview of the stages involved:
+
+## Prerequisites
+
+* A Gitlab project containing the project-factory repository
+* Available Gitlab Runners for the project either self hosted or the SaaS Gitlab shared runners.
+* A working WIF provider, pool setup with audience as gitlab.com with neccessary attributes and linked service account with required permissions. For further details, please refer to the official [Gitlab Documentation](https://docs.gitlab.com/ee/ci/cloud_services/google_cloud/)
+
+
+
+## Overview
+This workflow can execute terraform on different GCP projects depending on the branch on which push event is executed. Supports dev, staging and prod branches. The .gitlab-ci.yml file triggers the child pipeline on the respective branches and runs the workflow as specified in the workflow.yml file to execute terraform. All the three branches dev, staging and prod are linked to specific projects with DEV_, STAGE_, PROD_  CI/CD variables as specified in Gitlab project. For more information, see the setup section below
+
+
+## Setup 
+
+1. Update the CICD configuration file path in the repository
+    * From the skunkworks Gitlab project page, Navigate to Settings > CICD > expand General pipelines 
+    * update CI/CD configuration file value to the relative path of the gitlab-ci.yml file from the root directory
+
+2. Update the CI/CD variables
+    * From the skunkworks project page, Navigate to Settings > CICD > expand Variables
+    * Add the below variables to the pipeline 
+
+| Variable                       | Description                                                                                                                                              | Sample value                                                                                                    |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| DEV_GCP_PROJECT_ID             | The GCP project ID in which resources are to be created on a push event to dev branch                                                                    | sample-dev-project-1122                                                                                         |
+| DEV_GCP_SERVICE_ACCOUNT        | The Service Account of the dev gcp project configured with Workload Identity Federation (WIF)                                                            | xyz@sample-dev-project-1122.iam.gserviceaccount.com                                                             |
+| STAGE_GCP_PROJECT_ID           | The GCP project ID in which resources are to be created on a push event to staging branch                                                                | sample-stage-project-1122                                                                                       |
+| STAGE_GCP_SERVICE_ACCOUNT      | The Service Account of the staging gcp project configured with Workload Identity Federation (WIF)                                                        | xyz@sample-stage-project-1122.iam.gserviceaccount.com                                                           |
+| PROD_GCP_PROJECT_ID            | The GCP project ID in which resources are to be created on a push event to prod branch                                                                   | sample-prod-project-1122                                                                                        |
+| PROD_GCP_SERVICE_ACCOUNT       | The Service Account of the prod gcp project configured with Workload Identity Federation (WIF)                                                           | xyz@sample-prod-project-1122.iam.gserviceaccount.com                                                            |
+| GCP_WORKLOAD_IDENTITY_PROVIDER | The Workload Identity provider URI configured with the Service Account and the repository                                                                | projects/<project-number>/locations/global/workloadIdentityPools/<identity-pool-name>/providers/<provider-name> |
+| STATE_BUCKET                   | The GCS bucket in which the state is to be centrally managed. The Service account provided above must have access to list and write files to this bucket | sample-terraform-state-bucket                                                                                   |
+| TF_LOG                         | The terraform env variable setting to get detailed logs.  Supports TRACE,DEBUG,INFO,WARN,ERROR in order of decreasing verbosity                          | WARN                                                                                                            |
+| TF_ROOT                        | The directory of the terraform code to be executed.  Can be a path string or also a pre-defined gitlab CI variables                                      | $CI_PROJECT_DIR                                                                                                 |
+| TF_VERSION                     | The terraform version to be used for execution. The specified terraform version is downloaded and used for execution for the workflow.                   | 1.3.6                                                                                                           |                                                                                                          |
+
+## Overview of the Pipeline stages
+The complete workflow consists of 4 stages and 2 before-script jobs
+
+* before_script jobs : 
+    * gcp-auth : creates the wif credentials by impersonating the service account. 
+    * terraform init : initializes terraform in the specified TF_ROOT directory
+
+* Stages: 
+    * setup-terraform : Downloads the specified TF_VERSION and passes it as a binary to the next stages
+    * validate: Runs terraform fmt check and terraform validate. This stage fails if the code is not run against terraform fmt        command
+    * plan: Runs terraform plan and saves the plan and json version of the plan as artifacts
+    * apply: This step is currently set as manual to be triggered from the Gitlab pipelines UI once plan is successful. Runs terraform apply and creates the infrastructure specified.
+

--- a/examples/guardrails/skunkworks/.gitlab/workflows/workflow.yml
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/workflow.yml
@@ -1,0 +1,116 @@
+# Workflow image
+default:
+  image:
+    name: google/cloud-sdk:slim
+    # pull_policy: if-not-present  #Not allowed on the SaaS gitlab runners.
+
+# Workflow variables. They can be overwritten by passing pipeline Variables in Gitlab repository
+variables:
+  TF_PLAN_NAME: plan.tfplan
+  TF_PLAN_JSON: plan.json
+  REFRESH: -refresh=true
+
+# Provides a list of stages for this GitLab workflow
+stages:
+  - setup-terraform
+  - validate
+  - plan
+  - apply
+
+.gcp-auth: &gcp-auth
+    - echo ${CI_JOB_JWT_V2} > .ci_job_jwt_file
+    - gcloud iam workload-identity-pools create-cred-config ${GCP_WORKLOAD_IDENTITY_PROVIDER} --service-account="${GCP_SERVICE_ACCOUNT}" --output-file=.gcp_temp_cred.json --credential-source-file=.ci_job_jwt_file
+    - gcloud auth login --cred-file=`pwd`/.gcp_temp_cred.json
+    - gcloud config set project $GCP_PROJECT_ID
+    - export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/.gcp_temp_cred.json
+
+.terraform-ver-init: &terraform-ver-init
+  - cd $TF_ROOT
+  - cp ./terraform /usr/bin/
+  - terraform init -backend-config="bucket=$STATE_BUCKET" -backend-config="prefix=$CI_PROJECT_NAME/$GCP_PROJECT_ID" --upgrade=True
+
+# Cache files between jobs
+cache:
+  key: "$CI_COMMIT_SHA"
+  # Globally caches the .terraform folder across each job in this workflow
+  paths:
+    - $TF_ROOT/.terraform
+
+setup-terraform:
+  stage: setup-terraform
+  script:
+    - /bin/sh -c 'apt-get update && apt -y install unzip wget && wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && unzip terraform_${TF_VERSION}_linux_amd64.zip'
+  artifacts:
+    untracked: false
+    paths:
+      - terraform
+
+#Job: tf-fmt | Stage: validate
+# Purpose: check the format (fmt) as a sort of linting test
+tf-fmt:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform fmt -recursive -check
+  allow_failure: false
+    
+# Job: Validate | Stage: Validate
+# Purpose: Syntax Validation for the Terraform configuration files
+validate:
+  stage: validate
+  dependencies:
+    - setup-terraform
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  script:
+    - terraform validate
+  allow_failure: false
+
+#Job: plan | Stage: Plan
+#Runs terraform plan and outputs the plan and a json summary to 
+#local files which are later made available as artifacts.
+plan: 
+  stage: plan
+  dependencies:
+    - setup-terraform
+    - validate
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+    - apt install -y jq 
+    - shopt -s expand_aliases && alias convert_report="jq -r '([.resource_changes[]?.change.actions?]|flatten)|{\"create\":(map(select(.==\"create\"))|length),\"update\":(map(select(.==\"update\"))|length),\"delete\":(map(select(.==\"delete\"))|length)}'"
+  script:
+    - cd $TF_ROOT
+    - terraform plan -out=$TF_PLAN_NAME $REFRESH
+    - terraform show --json $TF_PLAN_NAME | convert_report > $TF_PLAN_JSON
+  allow_failure: false
+
+  artifacts:
+    reports:
+      terraform: ${TF_ROOT}/$TF_PLAN_JSON
+    paths:
+      - ${TF_ROOT}/$TF_PLAN_NAME
+      - ${TF_ROOT}/$TF_PLAN_JSON
+    expire_in: 7 days   #optional. Gitlab stores artifacts of successful pipelines for the most recent commit on each ref. If needed, enable "Keep artifacts from most recent successful jobs"  in CI/CD settings of the repository.
+
+#Stage:apply | job: apply
+# purpose: executes the plan from the file created in the plan stage
+apply:
+  stage: apply
+  environment: $ENVIRONMENT
+  before_script:
+    - *gcp-auth
+    - *terraform-ver-init
+  dependencies:
+    - setup-terraform
+    - plan
+  script:
+    - cd $TF_ROOT
+    - terraform apply -auto-approve $TF_PLAN_NAME 
+  when: manual
+  allow_failure: false

--- a/examples/guardrails/skunkworks/.gitlab/workflows/workflow.yml
+++ b/examples/guardrails/skunkworks/.gitlab/workflows/workflow.yml
@@ -112,5 +112,5 @@ apply:
   script:
     - cd $TF_ROOT
     - terraform apply -auto-approve $TF_PLAN_NAME 
-  when: manual
+  when: manual    #Set as manual currently as WIF doesn't support merge request pipelines for now.
   allow_failure: false


### PR DESCRIPTION
1. Added gitlab CI/CD workflows for folder-factory, project-factory and skunkworks.
2. Added support for allowed_audiences attribute for gitlab identity provider creation in project-factory
3. Added README.md files for gitlab workflows that contain the setup information and overview of the stages involved